### PR TITLE
List only base table, do not get views when call listTablesSql for MysqlDriver

### DIFF
--- a/src/Database/Schema/MysqlSchema.php
+++ b/src/Database/Schema/MysqlSchema.php
@@ -27,7 +27,7 @@ class MysqlSchema extends BaseSchema
      */
     public function listTablesSql($config)
     {
-        return ['SHOW TABLES FROM ' . $this->_driver->quoteIdentifier($config['database']), []];
+        return ['SHOW FULL TABLES FROM ' . $this->_driver->quoteIdentifier($config['database']) . "WHERE Table_Type = 'BASE TABLE'", []];
     }
 
     /**


### PR DESCRIPTION
This change add where for list table to get only a BASE TABLE, not view. The views on migrations snapshots cause errors, because the views is not a table to migrate.

I suggest this change to get only a base tables, when you want to list tables, because the SHOW TABLES query returns all tables and views, and in the most cases the views causes errors.
